### PR TITLE
change shebang of scripts to /bin/env bash

### DIFF
--- a/bspwm/bspwm_colors
+++ b/bspwm/bspwm_colors
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 bspc config focused_border_color "#0673a3"
 bspc config normal_border_color  "#044f6f"

--- a/bspwm/bspwm_colors.base
+++ b/bspwm/bspwm_colors.base
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 bspc config focused_border_color "#<COLORACT>"
 bspc config normal_border_color  "#<COLORIN>"

--- a/flattrcolor/scripts/change_all_folders.sh
+++ b/flattrcolor/scripts/change_all_folders.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # 64px folders
 #

--- a/flattrcolor/scripts/replace_folder_file.sh
+++ b/flattrcolor/scripts/replace_folder_file.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #	default color: 178984
 glyphColorOriginal=294045
 glyphColorNew=444d25

--- a/flattrcolor/scripts/replace_folder_file.sh.base
+++ b/flattrcolor/scripts/replace_folder_file.sh.base
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #	default color: 178984
 glyphColorOriginal=oldglyph
 glyphColorNew=newglyph

--- a/flattrcolor/scripts/replace_script.sh
+++ b/flattrcolor/scripts/replace_script.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 function replaceall {
 	cd ~/.icons/flattrcolor/scripts
 	#sh ./replace_folder_file.sh change_folder_colors.xslt


### PR DESCRIPTION
By changing the shebang, the script searches in the `$PATH` for bash, instead of assuming that bash is located at `/bin/`.

This change is necessary for Distributions like NixOS which store the binaries at another location.